### PR TITLE
Add IMA file signing for modern rosa platforms (rosa13/14/15...)

### DIFF
--- a/scripts/publisher.py
+++ b/scripts/publisher.py
@@ -66,6 +66,17 @@ if distrib_type == 'rhel':
     base_sign_cmd = '/usr/bin/rpmsign --addsign'
 
 
+# IMA file signatures: only for modern rosa platforms whose name is "rosa"
+# followed by exactly two digits (rosa13, rosa14, rosa15, ...). Older
+# platforms (rosa2012.1, rosa2016.1, rosa2019.0, rosa2021.1, ...) and
+# non-rosa platforms are skipped. Currently enabled for distrib_type='dnf'
+# only (the rpmsign backend); rhel may be added later.
+ima_key_path = '/root/ima/ima-private.pem'
+if build_for_platform and re.match(r'^rosa\d{2}$', build_for_platform) \
+        and distrib_type == 'dnf':
+    base_sign_cmd += ' --signfiles --fskpath={}'.format(ima_key_path)
+
+
 if released == 'false':
     status = 'release'
 if released == 'true':


### PR DESCRIPTION
Extend the rpm signing command with --signfiles --fskpath when BUILD_FOR_PLATFORM matches "rosa" + exactly two digits, so that IMA file signatures are added on top of the existing GPG header signature. Older platforms (rosa2012.1, rosa2016.1, rosa2019.0, rosa2021.1, ...) and non-rosa platforms are left unchanged.

Enabled for distrib_type='dnf' only (the rpmsign backend); rhel can also IMA-sign, rpm5 cannot.

rpm from rosa13 ust be used to sign so that everything works correctly.

Co-authored-by: Z.AI GLM