### PR TITLE
Exclude personal repositories from IMA file signing

### DIFF
--- a/scripts/publisher.py
+++ b/scripts/publisher.py
@@ -70,8 +70,15 @@ if distrib_type == 'rhel':
 # non-rosa platforms are skipped. Currently enabled for distrib_type='dnf'
 # only (the rpmsign backend); rhel may be added later.
 ima_key_path = '/root/ima/ima-private.pem'
-if build_for_platform and re.match(r'^rosa\d{2}$', build_for_platform) \
-        and distrib_type == 'dnf':
+# IMA file signing targets public modern rosa platforms only (rosa13, rosa14,
+# ...). Require the platform in PLATFORM_PATH to be rosa\d{2} (negative
+# lookahead avoids matching "rosa20" inside legacy "rosa2021.1") and skip
+# personal repositories, whose path contains '_personal'.
+if (build_for_platform and re.match(r'^rosa\d{2}$', build_for_platform)
+        and distrib_type == 'dnf'
+        and repository_path
+        and '_personal' not in repository_path
+        and re.search(r'rosa\d{2}(?!\d)', repository_path)):
     base_sign_cmd += ' --signfiles --fskpath={}'.format(ima_key_path)
 
 


### PR DESCRIPTION
A personal repo built on platform rosa13 passes the existing build_for_platform check (BUILD_FOR_PLATFORM=rosa13), so --signfiles was added for it too. IMA file signatures are meant for public modern rosa platforms only, so also require PLATFORM_PATH to contain a rosa\d{2} segment and not contain '_personal'. Negative lookahead (rosa\d{2}(?!\d)) prevents matching "rosa20" inside legacy "rosa2021.1".

Co-authored-by: Z.AI GLM